### PR TITLE
Validate background and logo inputs before generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Os endpoints expostos incluem listagem de templates, preview de HTML/CSS, upload
 ### Uso pela interface
 1. Clique em um dos formatos disponíveis (Feed, Stories etc.).
 2. Informe a URL da notícia. O front-end solicitará `/api/extract-news` para coletar título, descrição e imagem de destaque da página.【F:public/script.js†L116-L161】【F:server.js†L165-L214】
-3. Ajuste os campos opcionais e confirme. O navegador envia os dados para `/api/generate`, que grava `input/data.json`, executa `generate.js` e retorna os arquivos PNG gerados.【F:server.js†L91-L152】
+3. Ajuste os campos opcionais e confirme. O navegador envia os dados para `/api/generate`, que valida a presença de `bg` e `logo`, grava `input/data.json`, executa `generate.js` e retorna os arquivos PNG gerados. Em caso de erro de validação a API responde com HTTP 400 e detalhes dos campos ausentes.【F:server.js†L91-L170】
 4. Faça o download pelo link exibido na notificação.
 
 ### Uso por linha de comando
@@ -68,8 +68,8 @@ Prepare `input/data.json` com um array de objetos contendo os campos esperados p
     "h2": "Subtítulo opcional",
     "text": null,
     "tag": "Categoria",
-    "bg": "https://exemplo.com/imagem.jpg",
-    "logo": "nome_do_arquivo_sem_extensao"
+    "bg": "https://exemplo.com/imagem.jpg", // obrigatório, URL ou nome de arquivo presente em input/
+    "logo": "nome_do_arquivo_sem_extensao"   // obrigatório, URL ou nome de arquivo presente em input/
   }
 ]
 ```
@@ -77,7 +77,7 @@ Depois execute:
 ```bash
 npm run generate
 ```
-O script valida a presença do template, injeta os valores nos elementos com IDs correspondentes e exporta `arte_<template>_<pagina>_<n>.png` para a pasta configurada (por padrão `./output`). Ele aguarda explicitamente o carregamento das imagens para evitar artefatos parciais.【F:generate.js†L1-L111】【F:generate.js†L112-L155】
+O script valida a presença do template, certifica-se de que `bg` e `logo` são strings não vazias (evitando erros ao montar os caminhos das imagens), injeta os valores nos elementos com IDs correspondentes e exporta `arte_<template>_<pagina>_<n>.png` para a pasta configurada (por padrão `./output`). Ele aguarda explicitamente o carregamento das imagens para evitar artefatos parciais.【F:generate.js†L1-L118】【F:generate.js†L119-L162】
 
 ## Estrutura de diretórios
 

--- a/generate.js
+++ b/generate.js
@@ -76,15 +76,25 @@ async function waitForImages(page) {
       // Navega para o template
       await page.goto(templateURL, { waitUntil: 'networkidle0' });
 
-      const bgPath = bg.startsWith('http') ? bg : 'file://' + path.resolve('./input/' + bg + '.png');
-      const logoPath = logo.startsWith('http') ? logo : 'file://' + path.resolve('./input/' + logo + '.png');
+      if (typeof bg !== 'string' || !bg.trim().length) {
+        throw new Error('Parâmetro "bg" é obrigatório e deve ser uma string não vazia.');
+      }
+      if (typeof logo !== 'string' || !logo.trim().length) {
+        throw new Error('Parâmetro "logo" é obrigatório e deve ser uma string não vazia.');
+      }
+
+      const normalizedBg = bg.trim();
+      const normalizedLogo = logo.trim();
+
+      const bgPath = normalizedBg.startsWith('http') ? normalizedBg : 'file://' + path.resolve('./input/' + normalizedBg + '.png');
+      const logoPath = normalizedLogo.startsWith('http') ? normalizedLogo : 'file://' + path.resolve('./input/' + normalizedLogo + '.png');
 
       // Verifica se os arquivos de imagem existem
-      if (!bg.startsWith('http') && !fs.existsSync('./input/' + bg + '.png')) {
-        throw new Error(`Arquivo de background não encontrado: ${bg}.png`);
+      if (!normalizedBg.startsWith('http') && !fs.existsSync('./input/' + normalizedBg + '.png')) {
+        throw new Error(`Arquivo de background não encontrado: ${normalizedBg}.png`);
       }
-      if (!logo.startsWith('http') && !fs.existsSync('./input/' + logo + '.png')) {
-        throw new Error(`Arquivo de logo não encontrado: ${logo}.png`);
+      if (!normalizedLogo.startsWith('http') && !fs.existsSync('./input/' + normalizedLogo + '.png')) {
+        throw new Error(`Arquivo de logo não encontrado: ${normalizedLogo}.png`);
       }
 
       // Preenche os elementos de acordo com o template

--- a/server.js
+++ b/server.js
@@ -122,6 +122,36 @@ app.post('/api/generate', (req, res) => {
       return res.status(400).json({ error: 'Payload inválido: "artes" deve ser um array com ao menos um item.' });
     }
 
+    const validationErrors = [];
+
+    artes.forEach((arte, index) => {
+      const position = index + 1;
+
+      if (!arte || typeof arte !== 'object') {
+        validationErrors.push(`Arte ${position}: item inválido.`);
+        return;
+      }
+
+      if (typeof arte.bg !== 'string' || !arte.bg.trim().length) {
+        validationErrors.push(`Arte ${position}: o campo "bg" é obrigatório e deve ser uma string não vazia.`);
+      } else {
+        arte.bg = arte.bg.trim();
+      }
+
+      if (typeof arte.logo !== 'string' || !arte.logo.trim().length) {
+        validationErrors.push(`Arte ${position}: o campo "logo" é obrigatório e deve ser uma string não vazia.`);
+      } else {
+        arte.logo = arte.logo.trim();
+      }
+    });
+
+    if (validationErrors.length > 0) {
+      return res.status(400).json({
+        error: 'Dados inválidos para geração de artes.',
+        details: validationErrors
+      });
+    }
+
     if (isGenerating) {
       return res.status(409).json({ error: 'Já existe uma geração em andamento. Aguarde a conclusão antes de iniciar outra.' });
     }


### PR DESCRIPTION
## Summary
- validate background and logo values in generate.js before constructing file paths
- add request payload validation for bg/logo fields in /api/generate and normalize inputs
- document the required bg/logo fields for CLI and API usage in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfbee15c88331890a349146fbb5c4