### PR TITLE
feat: add dynamic story template selector for stories

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,57 +16,24 @@
             <p>Escolha o formato e gere sua arte:</p>
         </header>
 
-        <!-- Templates Grid -->
-        <main class="templates-grid">
-            <!-- Template A Gazeta Carrossel -->
-            <div class="template-card" data-template="TemplateAGazeta">
-                <div class="template-preview">
-                    <img src="previews/carrossel.jpg" alt="Template A Gazeta Carrossel" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
-                    <div class="template-placeholder" style="display: none;">
-                        <i class="fa-solid fa-file-image"></i>
-                    </div>
+        <!-- Templates Selector -->
+        <main class="templates-section">
+            <section class="template-selector" aria-labelledby="templateSelectorTitle">
+                <div class="selector-header">
+                    <h2 id="templateSelectorTitle">Templates de Stories</h2>
+                    <p>Filtre por categoria/cor para encontrar a variação ideal.</p>
                 </div>
-                <div class="template-info">
-                    <h3>A Gazeta - Feed</h3>
-                    <p>1080x1350px</p>
-                </div>
-            </div>
-
-            <!-- Template A Gazeta Feed -->
-            <div class="template-card" data-template="TemplateAGazetaFeed">
-                <div class="template-preview">
-                    <img src="previews/feed.jpg" alt="Template A Gazeta Feed" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
-                    <div class="template-placeholder" style="display: none;">
-                        <i class="fa-solid fa-image"></i>
-                    </div>
-                </div>
-                <div class="template-info">
-                    <h3>A Gazeta - Feed</h3>
-                    <p>1080x1080px</p>
-                </div>
-            </div>
-
-              <!-- Template A Gazeta Stories -->
-              <div class="template-card" data-template="TemplateAGazetaStories">
-                <div class="template-preview">
-                    <img src="previews/stories.jpg" alt="Template A Gazeta Stories" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
-                    <div class="template-placeholder" style="display: none;">
-                        <i class="fas fa-mobile-alt"></i>
-                    </div>
-                </div>
-                <div class="template-info">
-                    <h3>A Gazeta - Stories</h3>
-                    <p>1080x1920px</p>
-                </div>
-            </div>
+                <div class="template-tabs" id="categoryTabs" role="tablist" aria-label="Categorias de templates"></div>
+                <div class="templates-list" id="templatesList" aria-live="polite"></div>
+            </section>
         </main>
 
         <!-- Modal -->
-        <div class="modal" id="templateModal">
+        <div class="modal" id="templateModal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
             <div class="modal-content">
                 <div class="modal-header">
                     <h2 id="modalTitle">Gerar Arte</h2>
-                    <button class="close-btn" id="closeModal">
+                    <button class="close-btn" id="closeModal" aria-label="Fechar modal">
                         <i class="fas fa-times"></i>
                     </button>
                 </div>

--- a/public/previews/stories/README.md
+++ b/public/previews/stories/README.md
@@ -1,0 +1,19 @@
+# Previews dos templates de Stories
+
+Coloque neste diretório as imagens de pré-visualização utilizadas na lista de templates.
+Os arquivos referenciados pelo `public/script.js` são:
+
+- `foto-acima-titulo-azul.jpg`
+- `chamada-centro-azul.jpg`
+- `linha-base-azul.jpg`
+- `hz-ag-amarelo.jpg`
+- `card-informativo-amarelo.jpg`
+- `topo-faixa-amarelo.jpg`
+- `alerta-vertical-vermelho.jpg`
+- `foto-lateral-vermelho.jpg`
+- `headline-centro-vermelho.jpg`
+- `diagonal-verde.jpg`
+- `tag-circular-verde.jpg`
+- `lista-pontuada-verde.jpg`
+
+Essas imagens são opcionais: caso não existam, o cartão mostra um ícone de placeholder automaticamente.

--- a/public/script.js
+++ b/public/script.js
@@ -1,8 +1,86 @@
-// Estado da aplicação
+const storyTemplates = [
+    {
+        id: 'TemplateStoryFotoAcimaTituloAzul',
+        name: 'Foto acima · Título Azul',
+        category: 'Azul',
+        preview: 'previews/stories/foto-acima-titulo-azul.jpg'
+    },
+    {
+        id: 'TemplateStoryChamadaCentroAzul',
+        name: 'Chamada Central Azul',
+        category: 'Azul',
+        preview: 'previews/stories/chamada-centro-azul.jpg'
+    },
+    {
+        id: 'TemplateStoryLinhaBaseAzul',
+        name: 'Base Geométrica Azul',
+        category: 'Azul',
+        preview: 'previews/stories/linha-base-azul.jpg'
+    },
+    {
+        id: 'TemplateStoryHzAgAmarelo',
+        name: 'Faixas Horizontais Amarelas',
+        category: 'Amarelo',
+        preview: 'previews/stories/hz-ag-amarelo.jpg'
+    },
+    {
+        id: 'TemplateStoryCardInformativoAmarelo',
+        name: 'Card Informativo Amarelo',
+        category: 'Amarelo',
+        preview: 'previews/stories/card-informativo-amarelo.jpg'
+    },
+    {
+        id: 'TemplateStoryTopoFaixaAmarelo',
+        name: 'Faixa Superior Amarela',
+        category: 'Amarelo',
+        preview: 'previews/stories/topo-faixa-amarelo.jpg'
+    },
+    {
+        id: 'TemplateStoryAlertaVerticalVermelho',
+        name: 'Alerta Vertical Vermelho',
+        category: 'Vermelho',
+        preview: 'previews/stories/alerta-vertical-vermelho.jpg'
+    },
+    {
+        id: 'TemplateStoryFotoLateralVermelho',
+        name: 'Foto Lateral Vermelha',
+        category: 'Vermelho',
+        preview: 'previews/stories/foto-lateral-vermelho.jpg'
+    },
+    {
+        id: 'TemplateStoryHeadlineCentroVermelho',
+        name: 'Headline Central Vermelha',
+        category: 'Vermelho',
+        preview: 'previews/stories/headline-centro-vermelho.jpg'
+    },
+    {
+        id: 'TemplateStoryDiagonalVerde',
+        name: 'Diagonal Verde',
+        category: 'Verde',
+        preview: 'previews/stories/diagonal-verde.jpg'
+    },
+    {
+        id: 'TemplateStoryTagCircularVerde',
+        name: 'Tag Circular Verde',
+        category: 'Verde',
+        preview: 'previews/stories/tag-circular-verde.jpg'
+    },
+    {
+        id: 'TemplateStoryListaPontuadaVerde',
+        name: 'Lista Pontuada Verde',
+        category: 'Verde',
+        preview: 'previews/stories/lista-pontuada-verde.jpg'
+    }
+];
+
+const templateLookup = new Map(storyTemplates.map(template => [template.id, template]));
+
+let activeCategory = 'Todos';
 let currentTemplate = null;
 
 // Elementos DOM
-const templateCards = document.querySelectorAll('.template-card');
+const categoryTabsContainer = document.getElementById('categoryTabs');
+const templatesList = document.getElementById('templatesList');
 const modal = document.getElementById('templateModal');
 const closeModal = document.getElementById('closeModal');
 const cancelBtn = document.getElementById('cancelBtn');
@@ -17,63 +95,201 @@ const modalTitle = document.getElementById('modalTitle');
 
 // Inicialização
 document.addEventListener('DOMContentLoaded', () => {
+    renderCategoryTabs();
+    renderTemplateCards();
     setupEventListeners();
 });
 
+function renderCategoryTabs() {
+    if (!categoryTabsContainer) return;
+
+    const categories = ['Todos', ...new Set(storyTemplates.map(template => template.category))];
+    categoryTabsContainer.innerHTML = '';
+
+    categories.forEach(category => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'template-tab';
+        button.dataset.category = category;
+        button.textContent = category;
+        const isActive = category === activeCategory;
+        if (isActive) {
+            button.classList.add('active');
+        }
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        categoryTabsContainer.appendChild(button);
+    });
+}
+
+function renderTemplateCards() {
+    if (!templatesList) return;
+
+    templatesList.innerHTML = '';
+    const filteredTemplates = activeCategory === 'Todos'
+        ? storyTemplates
+        : storyTemplates.filter(template => template.category === activeCategory);
+
+    if (filteredTemplates.length === 0) {
+        const emptyMessage = document.createElement('p');
+        emptyMessage.className = 'no-templates';
+        emptyMessage.textContent = 'Nenhum template encontrado para esta categoria.';
+        templatesList.appendChild(emptyMessage);
+        return;
+    }
+
+    filteredTemplates.forEach(template => {
+        const card = document.createElement('article');
+        card.className = 'template-card';
+        card.dataset.template = template.id;
+        card.dataset.category = template.category;
+        card.tabIndex = 0;
+        card.setAttribute('role', 'button');
+        card.setAttribute('aria-label', `${template.name} (${template.category})`);
+
+        const preview = document.createElement('div');
+        preview.className = 'template-preview';
+
+        const img = document.createElement('img');
+        img.src = template.preview;
+        img.alt = `Pré-visualização do template ${template.name}`;
+
+        const placeholder = document.createElement('div');
+        placeholder.className = 'template-placeholder';
+        placeholder.innerHTML = '<i class="fa-solid fa-image"></i>';
+        placeholder.style.display = 'none';
+
+        img.addEventListener('error', () => {
+            img.style.display = 'none';
+            placeholder.style.display = 'flex';
+        });
+
+        preview.appendChild(img);
+        preview.appendChild(placeholder);
+
+        const info = document.createElement('div');
+        info.className = 'template-info';
+
+        const categoryPill = document.createElement('span');
+        categoryPill.className = 'template-category';
+        categoryPill.textContent = template.category;
+
+        const title = document.createElement('h3');
+        title.textContent = template.name;
+
+        const meta = document.createElement('p');
+        meta.className = 'template-meta';
+        meta.textContent = 'Stories · 1080x1920px';
+
+        info.appendChild(categoryPill);
+        info.appendChild(title);
+        info.appendChild(meta);
+
+        card.appendChild(preview);
+        card.appendChild(info);
+
+        templatesList.appendChild(card);
+    });
+}
+
 // Event Listeners
 function setupEventListeners() {
-    // Clique nos cards de template
-    templateCards.forEach(card => {
-        card.addEventListener('click', () => {
-            const template = card.dataset.template;
-            openModal(template);
+    if (categoryTabsContainer) {
+        categoryTabsContainer.addEventListener('click', handleCategoryClick);
+    }
+
+    if (templatesList) {
+        templatesList.addEventListener('click', handleTemplateSelection);
+        templatesList.addEventListener('keydown', handleTemplateKeyboardSelection);
+    }
+
+    if (closeModal) {
+        closeModal.addEventListener('click', closeModalHandler);
+    }
+
+    if (cancelBtn) {
+        cancelBtn.addEventListener('click', closeModalHandler);
+    }
+
+    if (modal) {
+        modal.addEventListener('click', (event) => {
+            if (event.target === modal) {
+                closeModalHandler();
+            }
         });
-    });
+    }
 
-    // Fechar modal
-    closeModal.addEventListener('click', closeModalHandler);
-    cancelBtn.addEventListener('click', closeModalHandler);
-    
-    // Clique fora do modal para fechar
-    modal.addEventListener('click', (e) => {
-        if (e.target === modal) {
-            closeModalHandler();
-        }
-    });
+    if (generateBtn) {
+        generateBtn.addEventListener('click', generateArt);
+    }
 
-    // Gerar arte
-    generateBtn.addEventListener('click', generateArt);
+    if (newsUrl) {
+        newsUrl.addEventListener('keypress', (event) => {
+            if (event.key === 'Enter') {
+                generateArt();
+            }
+        });
+    }
+}
 
-    // Enter no campo de URL
-    newsUrl.addEventListener('keypress', (e) => {
-        if (e.key === 'Enter') {
-            generateArt();
-        }
+function handleCategoryClick(event) {
+    const button = event.target.closest('.template-tab');
+    if (!button) return;
+
+    const { category } = button.dataset;
+    if (!category || category === activeCategory) {
+        return;
+    }
+
+    activeCategory = category;
+    updateActiveCategoryTab();
+    renderTemplateCards();
+}
+
+function updateActiveCategoryTab() {
+    if (!categoryTabsContainer) return;
+    const tabs = categoryTabsContainer.querySelectorAll('.template-tab');
+    tabs.forEach(tab => {
+        const isActive = tab.dataset.category === activeCategory;
+        tab.classList.toggle('active', isActive);
+        tab.setAttribute('aria-pressed', isActive ? 'true' : 'false');
     });
+}
+
+function handleTemplateSelection(event) {
+    const card = event.target.closest('.template-card');
+    if (!card) return;
+
+    const template = card.dataset.template;
+    openModal(template);
+}
+
+function handleTemplateKeyboardSelection(event) {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+        return;
+    }
+
+    const card = event.target.closest('.template-card');
+    if (!card) return;
+
+    event.preventDefault();
+    const template = card.dataset.template;
+    openModal(template);
 }
 
 // Abrir modal
 function openModal(template) {
     currentTemplate = template;
-    
-    // Atualizar título do modal
-    const templateNames = {
-        'TemplateAGazeta': 'Feed',
-        'TemplateAGazetaStories': 'Stories',
-        'TemplateAGazetaFeed': 'Feed',
-        'TemplateSimples': 'Simples',
-        'TemplateTopicos': 'Tópicos',
-        'TemplateCustom': 'Personalizado'
-    };
-    
-    modalTitle.textContent = `Gerar Arte - ${templateNames[template]}`;
-    
+
+    const templateInfo = templateLookup.get(template);
+    const templateName = templateInfo ? templateInfo.name : template;
+    modalTitle.textContent = `Gerar Arte - ${templateName}`;
+
     // Limpar campos
     newsUrl.value = '';
     customTitle.value = '';
     customSubtitle.value = '';
     customTag.value = '';
-    
+
     // Mostrar modal
     modal.classList.add('show');
     newsUrl.focus();
@@ -87,9 +303,14 @@ function closeModalHandler() {
 
 // Gerar arte
 async function generateArt() {
+    if (!currentTemplate) {
+        showToast('Por favor, selecione um template de story', 'error');
+        return;
+    }
+
     const url = newsUrl.value.trim();
     const tag = customTag.value.trim();
-    
+
     if (!url) {
         showToast('Por favor, insira o link da notícia', 'error');
         newsUrl.focus();
@@ -110,21 +331,21 @@ async function generateArt() {
 
     try {
         showLoading();
-        
+
         // Preparar dados
         const artData = {
             template: currentTemplate,
             page: 'pagina1',
             h1: customTitle.value.trim() || null,
             h2: customSubtitle.value.trim() || null,
-            tag: tag, // Tag obrigatória
-            bg: null, // Será preenchido pelo servidor
-            logo: 'logo' // Logo padrão
+            tag: tag,
+            bg: null,
+            logo: 'logo'
         };
 
         // Extrair dados da URL
         const extractedData = await extractNewsData(url);
-        
+
         // Atualizar dados com informações extraídas
         if (extractedData.h1 && !customTitle.value.trim()) {
             artData.h1 = extractedData.h1;
@@ -135,11 +356,9 @@ async function generateArt() {
         if (extractedData.bg) {
             artData.bg = extractedData.bg;
         }
-        // Tag sempre vem do usuário, não da extração automática
 
-        // Gerar arte
         const result = await generateArtwork([artData]);
-        
+
         if (result.success) {
             showToast('Arte gerada com sucesso!', 'success');
             showDownloadLink(result.filename);
@@ -147,7 +366,7 @@ async function generateArt() {
         } else {
             showToast('Erro ao gerar arte: ' + result.error, 'error');
         }
-        
+
     } catch (error) {
         console.error('Erro ao gerar arte:', error);
         showToast('Erro ao gerar arte: ' + error.message, 'error');
@@ -233,18 +452,17 @@ function hideLoading() {
 function showToast(message, type = 'info') {
     const toast = document.createElement('div');
     toast.className = `toast ${type}`;
-    
-    const icon = type === 'success' ? 'check-circle' : 
+
+    const icon = type === 'success' ? 'check-circle' :
                  type === 'error' ? 'exclamation-circle' : 'info-circle';
-    
+
     toast.innerHTML = `
         <i class="fas fa-${icon}"></i>
         <span>${message}</span>
     `;
-    
+
     toastContainer.appendChild(toast);
-    
-    // Remover após 5 segundos
+
     setTimeout(() => {
         toast.remove();
     }, 5000);
@@ -257,11 +475,9 @@ function showDownloadLink(filename) {
     downloadLink.download = filename;
     downloadLink.className = 'download-link';
     downloadLink.innerHTML = '<i class="fas fa-download"></i> Baixar Arte Gerada';
-    
-    // Adicionar ao container de toast
+
     toastContainer.appendChild(downloadLink);
-    
-    // Remover após 10 segundos
+
     setTimeout(() => {
         downloadLink.remove();
     }, 10000);
@@ -269,8 +485,5 @@ function showDownloadLink(filename) {
 
 // Criar pasta de previews se não existir
 function createPreviewsFolder() {
-    // Esta função pode ser chamada para criar a pasta previews
-    // onde você pode colocar as imagens de preview dos templates
-    console.log('Para adicionar previews dos templates, coloque as imagens na pasta: public/previews/');
-    console.log('Nomes sugeridos: template1.jpg, template2.jpg, template3.jpg, template4.jpg');
+    console.log('Para adicionar previews dos templates, coloque as imagens na pasta: public/previews/stories');
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -7,74 +7,139 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: #fff;
+    background: #f4f7fb;
     min-height: 100vh;
-    color: #333;
+    color: #1f2937;
     line-height: 1.6;
 }
 
 .container {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 40px 20px;
+    padding: 40px 20px 80px;
     min-height: 100vh;
 }
 
 /* Header */
 .header {
     text-align: center;
-    margin-bottom: 60px;
-    color: white;
+    margin-bottom: 50px;
 }
 
 .header h1 {
-    color: #619ec8;
+    color: #1d4f91;
     font-size: 3rem;
     font-weight: 700;
-    margin-bottom: 15px;
-    text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    margin-bottom: 12px;
 }
 
 .header p {
     font-size: 1.2rem;
-    opacity: 0.9;
-    font-weight: 300;
-    color: #619ec8;
+    font-weight: 400;
+    color: #3b82f6;
 }
 
-/* Templates Grid */
-.templates-grid {
+/* Template Selector */
+.templates-section {
+    display: flex;
+    justify-content: center;
+}
+
+.template-selector {
+    width: 100%;
+    max-width: 1080px;
+    background: #ffffff;
+    border-radius: 28px;
+    padding: 36px 40px 44px;
+    box-shadow: 0 20px 60px rgba(30, 64, 175, 0.12);
+}
+
+.selector-header {
+    text-align: center;
+    margin-bottom: 28px;
+}
+
+.selector-header h2 {
+    font-size: 1.8rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 8px;
+}
+
+.selector-header p {
+    color: #6b7280;
+}
+
+.template-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+    margin-bottom: 32px;
+}
+
+.template-tab {
+    border: 1px solid transparent;
+    background: #f1f5f9;
+    color: #1f2937;
+    padding: 10px 22px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+}
+
+.template-tab:hover {
+    background: #e2e8f0;
+}
+
+.template-tab.active {
+    background: #1d4f91;
+    color: #ffffff;
+    box-shadow: 0 8px 20px rgba(29, 79, 145, 0.4);
+}
+
+.template-tab:focus-visible {
+    outline: 3px solid rgba(59, 130, 246, 0.65);
+    outline-offset: 3px;
+}
+
+.templates-list {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 30px;
-    max-width: 1000px;
-    margin: 0 auto;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 28px;
 }
 
 .template-card {
-    background: white;
-    border-radius: 20px;
+    background: #ffffff;
+    border-radius: 22px;
     overflow: hidden;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    box-shadow: 0 14px 40px rgba(15, 23, 42, 0.12);
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
     position: relative;
+    display: flex;
+    flex-direction: column;
+    min-height: 340px;
 }
 
 .template-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+    transform: translateY(-8px);
+    box-shadow: 0 20px 55px rgba(15, 23, 42, 0.18);
 }
 
-.template-card:active {
-    transform: translateY(-5px);
+.template-card:focus-visible {
+    outline: 3px solid #1d4f91;
+    outline-offset: 4px;
 }
 
 .template-preview {
     position: relative;
     height: 200px;
     overflow: hidden;
-    background: #f8f9fa;
+    background: #f1f5f9;
 }
 
 .template-preview img {
@@ -94,26 +159,51 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #619dc7;
+    background: #1d4f91;
     color: white;
-    font-size: 4rem;
+    font-size: 3rem;
 }
 
 .template-info {
-    padding: 25px;
-    text-align: center;
+    padding: 24px 26px 30px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    flex: 1;
+}
+
+.template-category {
+    display: inline-flex;
+    align-self: flex-start;
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(29, 79, 145, 0.12);
+    color: #1d4f91;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
 }
 
 .template-info h3 {
-    font-size: 1.5rem;
+    font-size: 1.35rem;
     font-weight: 600;
-    margin-bottom: 8px;
-    color: #2d3748;
+    color: #111827;
 }
 
-.template-info p {
-    color: #718096;
-    font-size: 1rem;
+.template-meta {
+    color: #6b7280;
+    font-size: 0.95rem;
+}
+
+.no-templates {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: 40px 20px;
+    border-radius: 20px;
+    background: #f8fafc;
+    color: #4b5563;
+    font-weight: 500;
 }
 
 /* Modal */
@@ -166,7 +256,7 @@ body {
 .modal-header h2 {
     font-size: 1.8rem;
     font-weight: 600;
-    color: #2d3748;
+    color: #1f2937;
 }
 
 .close-btn {
@@ -219,9 +309,9 @@ body {
 
 .form-group input:focus {
     outline: none;
-    border-color: #667eea;
+    border-color: #3b82f6;
     background: white;
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
 }
 
 .form-group input::placeholder {
@@ -258,14 +348,14 @@ body {
 }
 
 .btn-primary {
-    background: linear-gradient(135deg, #667eea, #764ba2);
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
     color: white;
-    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 4px 15px rgba(37, 99, 235, 0.35);
 }
 
 .btn-primary:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);
+    box-shadow: 0 8px 25px rgba(37, 99, 235, 0.45);
 }
 
 .btn-primary:active {
@@ -336,7 +426,7 @@ body {
     padding: 15px 20px;
     margin-bottom: 10px;
     box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-    border-left: 4px solid #667eea;
+    border-left: 4px solid #2563eb;
     animation: slideInRight 0.3s ease;
     max-width: 350px;
     display: flex;
@@ -374,7 +464,7 @@ body {
     display: inline-block;
     margin-top: 15px;
     padding: 10px 20px;
-    background: #48bb78;
+    background: #10b981;
     color: white;
     text-decoration: none;
     border-radius: 8px;
@@ -383,60 +473,54 @@ body {
 }
 
 .download-link:hover {
-    background: #38a169;
+    background: #059669;
     transform: translateY(-2px);
 }
 
 /* Responsive */
-@media (max-width: 768px) {
-    .container {
-        padding: 20px 15px;
+@media (max-width: 1024px) {
+    .template-selector {
+        padding: 32px 28px;
     }
-    
-    .header h1 {
-        font-size: 2.2rem;
-    }
-    
-    .templates-grid {
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+
+    .templates-list {
         gap: 20px;
-    }
-    
-    .template-preview {
-        height: 150px;
-    }
-    
-    .modal-content {
-        width: 95%;
-        margin: 20px;
-    }
-    
-    .modal-header,
-    .modal-body,
-    .modal-footer {
-        padding: 20px;
-    }
-    
-    .modal-footer {
-        flex-direction: column;
-    }
-    
-    .btn {
-        width: 100%;
-        justify-content: center;
     }
 }
 
-@media (max-width: 480px) {
-    .templates-grid {
-        grid-template-columns: 1fr;
+@media (max-width: 768px) {
+    .container {
+        padding: 20px 15px 60px;
     }
-    
+
     .header h1 {
-        font-size: 1.8rem;
+        font-size: 2.3rem;
     }
-    
-    .template-info h3 {
-        font-size: 1.3rem;
+
+    .template-selector {
+        padding: 28px 20px 32px;
+    }
+
+    .template-tabs {
+        justify-content: flex-start;
+    }
+
+    .template-card {
+        min-height: 320px;
+    }
+}
+
+@media (max-width: 540px) {
+    .template-tabs {
+        gap: 8px;
+    }
+
+    .template-tab {
+        padding: 8px 16px;
+        font-size: 0.85rem;
+    }
+
+    .template-preview {
+        height: 180px;
     }
 }

--- a/templates/TemplateStoryAlertaVerticalVermelho/pagina1/index.html
+++ b/templates/TemplateStoryAlertaVerticalVermelho/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Alerta Vertical Vermelho</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Alerta vertical enfatiza notícias urgentes e breaking news</h1>
+      <p class="subtitle" id="subtitle">Espaço para subtítulo reforçando o fato com contexto adicional e dados.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryAlertaVerticalVermelho/pagina1/styles.css
+++ b/templates/TemplateStoryAlertaVerticalVermelho/pagina1/styles.css
@@ -1,0 +1,109 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #2b0505;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: #1c0001;
+  color: #ffebeb;
+  overflow: hidden;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(0.4);
+  opacity: 0.28;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 74, 74, 0.35) 0%, rgba(28, 0, 1, 0.95) 55%, rgba(28, 0, 1, 1) 100%);
+  z-index: 2;
+}
+
+#art::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 220px;
+  height: 100%;
+  background: linear-gradient(180deg, #ff1a2d 0%, #a00011 100%);
+  z-index: 3;
+  box-shadow: 12px 0 40px rgba(255, 26, 45, 0.35);
+}
+
+#logo {
+  position: absolute;
+  top: 120px;
+  right: 120px;
+  width: 180px;
+  height: 180px;
+  object-fit: contain;
+  z-index: 5;
+}
+
+.content {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: calc(100% - 220px);
+  height: 100%;
+  padding: 200px 140px 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+  z-index: 4;
+}
+
+.tag {
+  position: absolute;
+  top: 240px;
+  left: 40px;
+  width: 140px;
+  padding: 18px 0;
+  background: #1c0001;
+  color: #ff1a2d;
+  font-weight: 800;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  writing-mode: vertical-rl;
+  text-align: center;
+  border-radius: 28px;
+  box-shadow: inset 0 0 0 4px rgba(255, 26, 45, 0.45);
+}
+
+#title {
+  font-size: 4.6rem;
+  line-height: 1.1;
+  font-weight: 800;
+  color: #ffffff;
+  text-transform: uppercase;
+  text-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+}
+
+.subtitle {
+  font-size: 2.2rem;
+  line-height: 1.5;
+  color: #ffc4c4;
+  max-width: 720px;
+}

--- a/templates/TemplateStoryCardInformativoAmarelo/pagina1/index.html
+++ b/templates/TemplateStoryCardInformativoAmarelo/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Card Informativo Amarelo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Card informativo destaca dados e números importantes</h1>
+      <p class="subtitle" id="subtitle">Campo complementar para contextualização rápida e chamada à ação.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryCardInformativoAmarelo/pagina1/styles.css
+++ b/templates/TemplateStoryCardInformativoAmarelo/pagina1/styles.css
@@ -1,0 +1,103 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #2a1700;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: linear-gradient(180deg, #2a1700 0%, #1a0f00 100%);
+  color: #1a0f00;
+  overflow: hidden;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.6);
+  opacity: 0.25;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% -10%, rgba(255, 191, 0, 0.55), transparent 65%), rgba(26, 15, 0, 0.85);
+  z-index: 2;
+}
+
+#logo {
+  position: absolute;
+  top: 80px;
+  right: 80px;
+  width: 190px;
+  height: 190px;
+  object-fit: contain;
+  z-index: 4;
+}
+
+.content {
+  position: relative;
+  z-index: 5;
+  width: 840px;
+  margin: 320px auto 0;
+  background: #ffe082;
+  border-radius: 48px;
+  padding: 120px 110px;
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.content::before {
+  content: '';
+  position: absolute;
+  top: -70px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, rgba(255, 224, 130, 0.5), transparent 70%);
+  filter: blur(12px);
+  z-index: -1;
+}
+
+.tag {
+  align-self: flex-start;
+  padding: 10px 26px;
+  border-radius: 999px;
+  background: #1a0f00;
+  color: #ffe082;
+  font-size: 1.8rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+#title {
+  font-size: 4.3rem;
+  line-height: 1.15;
+  font-weight: 800;
+  color: #1a0f00;
+}
+
+.subtitle {
+  font-size: 2.1rem;
+  line-height: 1.5;
+  color: #3f2500;
+}

--- a/templates/TemplateStoryChamadaCentroAzul/pagina1/index.html
+++ b/templates/TemplateStoryChamadaCentroAzul/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Chamada Centro Azul</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Chamada principal centralizada com destaque em azul</h1>
+      <p class="subtitle" id="subtitle">Espaço reservado para subtítulo complementar com contexto adicional.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryChamadaCentroAzul/pagina1/styles.css
+++ b/templates/TemplateStoryChamadaCentroAzul/pagina1/styles.css
@@ -1,0 +1,95 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #06152a;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: radial-gradient(circle at 50% 20%, rgba(76, 161, 255, 0.55), transparent 55%), #0c1f3f;
+  overflow: hidden;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  mix-blend-mode: lighten;
+  opacity: 0.35;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(6, 21, 42, 0.2) 0%, rgba(6, 21, 42, 0.85) 100%);
+  z-index: 2;
+}
+
+#logo {
+  position: absolute;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 200px;
+  height: 200px;
+  object-fit: contain;
+  z-index: 4;
+}
+
+.content {
+  position: relative;
+  z-index: 5;
+  max-width: 860px;
+  padding: 160px 120px;
+  background: rgba(6, 21, 42, 0.82);
+  border-radius: 48px;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 24px 80px rgba(6, 21, 42, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.tag {
+  align-self: center;
+  padding: 14px 30px;
+  border-radius: 999px;
+  background: rgba(78, 161, 255, 0.2);
+  color: #4ea1ff;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  font-size: 1.8rem;
+}
+
+#title {
+  font-size: 4.8rem;
+  line-height: 1.1;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.subtitle {
+  font-size: 2.1rem;
+  line-height: 1.5;
+  color: #d8e9ff;
+}

--- a/templates/TemplateStoryDiagonalVerde/pagina1/index.html
+++ b/templates/TemplateStoryDiagonalVerde/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Diagonal Verde</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Faixa diagonal cria movimento para destacar a manchete</h1>
+      <p class="subtitle" id="subtitle">Use este campo para complementar o título com contexto, dados ou serviço.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryDiagonalVerde/pagina1/styles.css
+++ b/templates/TemplateStoryDiagonalVerde/pagina1/styles.css
@@ -1,0 +1,110 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #012015;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: #012015;
+  color: #e9fff4;
+  overflow: hidden;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.3;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(1, 32, 21, 0.85) 0%, rgba(1, 32, 21, 0.75) 50%, rgba(1, 32, 21, 0.4) 100%);
+  z-index: 2;
+}
+
+#art::before {
+  content: '';
+  position: absolute;
+  top: -20%;
+  left: -15%;
+  width: 140%;
+  height: 60%;
+  background: linear-gradient(120deg, rgba(0, 255, 171, 0.35), rgba(0, 204, 133, 0.6));
+  transform: rotate(-12deg);
+  z-index: 3;
+}
+
+#art::after {
+  content: '';
+  position: absolute;
+  bottom: -35%;
+  right: -20%;
+  width: 130%;
+  height: 60%;
+  background: linear-gradient(120deg, rgba(0, 204, 133, 0.45), rgba(0, 153, 102, 0.65));
+  transform: rotate(18deg);
+  z-index: 0;
+}
+
+#logo {
+  position: absolute;
+  top: 90px;
+  right: 90px;
+  width: 170px;
+  height: 170px;
+  object-fit: contain;
+  z-index: 5;
+}
+
+.content {
+  position: relative;
+  z-index: 6;
+  padding: 460px 120px 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.tag {
+  align-self: flex-start;
+  padding: 12px 30px;
+  border-radius: 999px;
+  background: rgba(0, 255, 171, 0.2);
+  color: #00ffab;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 1.8rem;
+}
+
+#title {
+  font-size: 4.5rem;
+  line-height: 1.1;
+  font-weight: 800;
+  max-width: 780px;
+  text-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+}
+
+.subtitle {
+  font-size: 2.1rem;
+  line-height: 1.45;
+  color: #bfffe3;
+  max-width: 720px;
+}

--- a/templates/TemplateStoryFotoAcimaTituloAzul/pagina1/index.html
+++ b/templates/TemplateStoryFotoAcimaTituloAzul/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Foto Acima Azul</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Título principal da notícia ocupa duas linhas nesta área</h1>
+      <p class="subtitle" id="subtitle">Subtítulo opcional com informação complementar do fato em destaque.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryFotoAcimaTituloAzul/pagina1/styles.css
+++ b/templates/TemplateStoryFotoAcimaTituloAzul/pagina1/styles.css
@@ -1,0 +1,104 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #021b33;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: #021b33;
+  color: #ffffff;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+}
+
+#bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 65%;
+  object-fit: cover;
+  filter: saturate(1.1);
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 65%;
+  background: linear-gradient(180deg, rgba(2, 27, 51, 0) 0%, rgba(2, 27, 51, 0.55) 60%, #021b33 100%);
+  z-index: 2;
+}
+
+#art::after {
+  content: '';
+  position: absolute;
+  bottom: -160px;
+  left: -200px;
+  width: 520px;
+  height: 520px;
+  background: radial-gradient(circle, rgba(78, 163, 255, 0.4), transparent 70%);
+  z-index: 0;
+}
+
+#logo {
+  position: absolute;
+  top: 72px;
+  right: 72px;
+  width: 160px;
+  height: 160px;
+  object-fit: contain;
+  z-index: 3;
+}
+
+.content {
+  position: relative;
+  z-index: 4;
+  padding: 120px 96px 140px;
+  width: 100%;
+  background: linear-gradient(0deg, rgba(2, 27, 51, 0.92) 0%, rgba(2, 27, 51, 0.85) 55%, rgba(2, 27, 51, 0) 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.tag {
+  align-self: flex-start;
+  background: #4ea3ff;
+  color: #021b33;
+  padding: 12px 28px;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 2rem;
+}
+
+#title {
+  font-size: 4.4rem;
+  font-weight: 700;
+  line-height: 1.1;
+  text-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.subtitle {
+  font-size: 2rem;
+  line-height: 1.4;
+  color: #d6e8ff;
+  max-width: 780px;
+}

--- a/templates/TemplateStoryFotoLateralVermelho/pagina1/index.html
+++ b/templates/TemplateStoryFotoLateralVermelho/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Foto Lateral Vermelho</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Imagem lateral dá suporte ao título alinhado à esquerda</h1>
+      <p class="subtitle" id="subtitle">Use este espaço para complementar a notícia com detalhes e contexto adicional.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryFotoLateralVermelho/pagina1/styles.css
+++ b/templates/TemplateStoryFotoLateralVermelho/pagina1/styles.css
@@ -1,0 +1,99 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #2b0404;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: #2b0404;
+  overflow: hidden;
+  color: #ffe3e3;
+}
+
+#bg {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 60%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 1;
+  filter: saturate(1.2);
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(43, 4, 4, 1) 0%, rgba(43, 4, 4, 0.4) 45%, rgba(43, 4, 4, 0.1) 100%);
+  z-index: 2;
+}
+
+#art::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+  height: 50%;
+  background: radial-gradient(circle at 10% 90%, rgba(255, 77, 77, 0.5), transparent 70%);
+  z-index: 0;
+}
+
+#logo {
+  position: absolute;
+  top: 90px;
+  left: 90px;
+  width: 200px;
+  height: 200px;
+  object-fit: contain;
+  z-index: 4;
+}
+
+.content {
+  position: absolute;
+  top: 280px;
+  left: 90px;
+  width: 54%;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  z-index: 5;
+}
+
+.tag {
+  padding: 12px 28px;
+  background: #ff2d3b;
+  color: #2b0404;
+  font-weight: 800;
+  font-size: 1.9rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  width: fit-content;
+  border-radius: 999px;
+  box-shadow: 0 12px 28px rgba(255, 45, 59, 0.4);
+}
+
+#title {
+  font-size: 4.4rem;
+  line-height: 1.15;
+  font-weight: 800;
+  text-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+}
+
+.subtitle {
+  font-size: 2.1rem;
+  line-height: 1.5;
+  color: #ffd0d0;
+}

--- a/templates/TemplateStoryHeadlineCentroVermelho/pagina1/index.html
+++ b/templates/TemplateStoryHeadlineCentroVermelho/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Headline Centro Vermelho</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Headline centralizada com moldura intensa em vermelho</h1>
+      <p class="subtitle" id="subtitle">Descrição complementar para explicar detalhes rápidos e orientar a leitura.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryHeadlineCentroVermelho/pagina1/styles.css
+++ b/templates/TemplateStoryHeadlineCentroVermelho/pagina1/styles.css
@@ -1,0 +1,114 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #320202;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: radial-gradient(circle at 50% 10%, rgba(255, 78, 78, 0.45), transparent 60%), #200001;
+  color: #ffe5e5;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.3;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(32, 0, 1, 0.8);
+  z-index: 2;
+}
+
+#logo {
+  position: absolute;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 180px;
+  height: 180px;
+  object-fit: contain;
+  z-index: 5;
+}
+
+.content {
+  position: relative;
+  z-index: 4;
+  width: 820px;
+  padding: 140px 110px;
+  border-radius: 48px;
+  border: 6px solid rgba(255, 78, 78, 0.8);
+  background: rgba(32, 0, 1, 0.8);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.55);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.content::before,
+.content::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 12px solid rgba(255, 78, 78, 0.3);
+  transform: translateX(-50%);
+}
+
+.content::before {
+  top: -80px;
+}
+
+.content::after {
+  bottom: -80px;
+}
+
+.tag {
+  align-self: center;
+  padding: 12px 28px;
+  border-radius: 999px;
+  background: rgba(255, 78, 78, 0.15);
+  color: #ff4e4e;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 1.8rem;
+}
+
+#title {
+  font-size: 4.6rem;
+  line-height: 1.1;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.subtitle {
+  font-size: 2.2rem;
+  line-height: 1.5;
+  color: #ffc9c9;
+}

--- a/templates/TemplateStoryHzAgAmarelo/pagina1/index.html
+++ b/templates/TemplateStoryHzAgAmarelo/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Hz Ag Amarelo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Layout horizontal com faixas e destaque em amarelo</h1>
+      <p class="subtitle" id="subtitle">Linha auxiliar para complementar o chamado principal com informação adicional.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryHzAgAmarelo/pagina1/styles.css
+++ b/templates/TemplateStoryHzAgAmarelo/pagina1/styles.css
@@ -1,0 +1,130 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #1f1400;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: #1f1400;
+  color: #1f1400;
+  overflow: hidden;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(40%);
+  opacity: 0.35;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 202, 40, 0.15) 0%, rgba(31, 20, 0, 0.9) 100%);
+  z-index: 2;
+}
+
+#art::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 35%;
+  background: linear-gradient(90deg, rgba(255, 218, 80, 0.9) 0%, rgba(255, 193, 7, 0.65) 50%, rgba(255, 166, 0, 0.45) 100%);
+  z-index: 0;
+}
+
+#art::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 30%;
+  background: linear-gradient(0deg, rgba(31, 20, 0, 1) 0%, rgba(31, 20, 0, 0) 100%);
+  z-index: 3;
+}
+
+#logo {
+  position: absolute;
+  top: 90px;
+  left: 90px;
+  width: 200px;
+  height: 200px;
+  object-fit: contain;
+  z-index: 4;
+}
+
+.content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 140px 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+  z-index: 5;
+}
+
+.content::before,
+.content::after {
+  content: '';
+  position: absolute;
+  left: 120px;
+  width: calc(100% - 240px);
+  height: 10px;
+  background: linear-gradient(90deg, #ffda50 0%, transparent 100%);
+}
+
+.content::before {
+  top: -70px;
+}
+
+.content::after {
+  top: -30px;
+}
+
+.tag {
+  align-self: flex-start;
+  padding: 14px 30px;
+  border-radius: 999px;
+  background: #ffda50;
+  color: #1f1400;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 2rem;
+}
+
+#title {
+  font-size: 4.2rem;
+  line-height: 1.12;
+  font-weight: 800;
+  color: #fffbf0;
+  text-shadow: 0 10px 32px rgba(0, 0, 0, 0.45);
+}
+
+.subtitle {
+  font-size: 2.1rem;
+  line-height: 1.5;
+  color: #ffe9a6;
+  max-width: 720px;
+}

--- a/templates/TemplateStoryLinhaBaseAzul/pagina1/index.html
+++ b/templates/TemplateStoryLinhaBaseAzul/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Linha Base Azul</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Título com base geométrica reforça o destaque principal</h1>
+      <p class="subtitle" id="subtitle">Texto auxiliar descrevendo informações rápidas ou dados em destaque.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryLinhaBaseAzul/pagina1/styles.css
+++ b/templates/TemplateStoryLinhaBaseAzul/pagina1/styles.css
@@ -1,0 +1,132 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #03111f;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  overflow: hidden;
+  background: #03111f;
+  color: #f5fbff;
+}
+
+#art::before {
+  content: '';
+  position: absolute;
+  bottom: -120px;
+  left: -160px;
+  width: 720px;
+  height: 720px;
+  background: radial-gradient(circle, rgba(86, 177, 255, 0.45), transparent 70%);
+  z-index: 0;
+}
+
+#art::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 70%;
+  height: 45%;
+  background: linear-gradient(135deg, rgba(3, 17, 31, 0) 0%, rgba(22, 66, 108, 0.75) 45%, rgba(5, 34, 58, 0.95) 100%);
+  z-index: 1;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.5;
+  z-index: 0;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(3, 17, 31, 0.25) 0%, rgba(3, 17, 31, 0.85) 100%);
+  z-index: 2;
+}
+
+#logo {
+  position: absolute;
+  top: 80px;
+  left: 80px;
+  width: 180px;
+  height: 180px;
+  object-fit: contain;
+  z-index: 4;
+}
+
+.content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  padding: 120px 120px 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  z-index: 5;
+}
+
+.content::before {
+  content: '';
+  position: absolute;
+  top: -40px;
+  left: 120px;
+  width: 280px;
+  height: 8px;
+  background: linear-gradient(90deg, #4ea3ff, transparent);
+}
+
+.content::after {
+  content: '';
+  position: absolute;
+  bottom: 90px;
+  right: 120px;
+  width: 160px;
+  height: 160px;
+  border: 12px solid rgba(78, 163, 255, 0.35);
+  border-radius: 24px;
+  z-index: -1;
+}
+
+.tag {
+  font-size: 1.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  background: rgba(78, 163, 255, 0.16);
+  color: #4ea3ff;
+  padding: 12px 32px;
+  width: fit-content;
+  border-radius: 999px;
+}
+
+#title {
+  font-size: 4.2rem;
+  line-height: 1.15;
+  max-width: 760px;
+  text-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+}
+
+.subtitle {
+  font-size: 2rem;
+  line-height: 1.45;
+  color: #d2e6ff;
+  max-width: 680px;
+}

--- a/templates/TemplateStoryListaPontuadaVerde/pagina1/index.html
+++ b/templates/TemplateStoryListaPontuadaVerde/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Lista Pontuada Verde</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Lista pontuada ajuda a organizar tópicos importantes</h1>
+      <p class="subtitle" id="subtitle">Texto adicional com bullets pode ser inserido aqui para reforçar os destaques.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryListaPontuadaVerde/pagina1/styles.css
+++ b/templates/TemplateStoryListaPontuadaVerde/pagina1/styles.css
@@ -1,0 +1,116 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #002819;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: linear-gradient(180deg, #002819 0%, #001b11 100%);
+  overflow: hidden;
+  color: #dcffef;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.25;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 40, 25, 0.85);
+  z-index: 2;
+}
+
+#art::before {
+  content: '';
+  position: absolute;
+  left: 80px;
+  top: 140px;
+  width: 12px;
+  height: calc(100% - 280px);
+  background: linear-gradient(180deg, #00d68f 0%, transparent 100%);
+  border-radius: 999px;
+  z-index: 3;
+}
+
+#logo {
+  position: absolute;
+  top: 90px;
+  right: 90px;
+  width: 180px;
+  height: 180px;
+  object-fit: contain;
+  z-index: 4;
+}
+
+.content {
+  position: relative;
+  z-index: 5;
+  padding: 260px 140px 160px 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  max-width: 780px;
+}
+
+.content::before,
+.content::after {
+  content: '';
+  position: absolute;
+  left: -80px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #00d68f;
+  box-shadow: 0 0 0 10px rgba(0, 214, 143, 0.2);
+}
+
+.content::before {
+  top: 220px;
+}
+
+.content::after {
+  top: 420px;
+}
+
+.tag {
+  padding: 12px 28px;
+  border-radius: 999px;
+  background: rgba(0, 214, 143, 0.15);
+  color: #00d68f;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  width: fit-content;
+}
+
+#title {
+  font-size: 4.3rem;
+  line-height: 1.15;
+  font-weight: 800;
+  text-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+}
+
+.subtitle {
+  font-size: 2.1rem;
+  line-height: 1.5;
+  color: #b8ffe4;
+}

--- a/templates/TemplateStoryTagCircularVerde/pagina1/index.html
+++ b/templates/TemplateStoryTagCircularVerde/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Tag Circular Verde</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Tag circular destaca a editoria com visual moderno</h1>
+      <p class="subtitle" id="subtitle">Subtítulo auxiliar explica o tema abordado e incentiva a leitura completa.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryTagCircularVerde/pagina1/styles.css
+++ b/templates/TemplateStoryTagCircularVerde/pagina1/styles.css
@@ -1,0 +1,98 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #012d20;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: #012d20;
+  overflow: hidden;
+  color: #e6fff5;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.25;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 70% 30%, rgba(0, 191, 143, 0.4), transparent 65%), rgba(1, 45, 32, 0.85);
+  z-index: 2;
+}
+
+#logo {
+  position: absolute;
+  top: 90px;
+  left: 90px;
+  width: 180px;
+  height: 180px;
+  object-fit: contain;
+  z-index: 4;
+}
+
+.content {
+  position: relative;
+  z-index: 5;
+  padding: 360px 120px 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  max-width: 820px;
+}
+
+.tag {
+  position: relative;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #00bf8f 0%, #009f73 100%);
+  color: #012d20;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+  box-shadow: 0 18px 44px rgba(0, 191, 143, 0.35);
+}
+
+.tag::after {
+  content: '';
+  position: absolute;
+  inset: -24px;
+  border-radius: 50%;
+  border: 6px solid rgba(0, 191, 143, 0.3);
+}
+
+#title {
+  font-size: 4.3rem;
+  line-height: 1.12;
+  font-weight: 800;
+  text-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+}
+
+.subtitle {
+  font-size: 2.1rem;
+  line-height: 1.45;
+  color: #c6ffeb;
+}

--- a/templates/TemplateStoryTopoFaixaAmarelo/pagina1/index.html
+++ b/templates/TemplateStoryTopoFaixaAmarelo/pagina1/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Template Story Topo Faixa Amarelo</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="art">
+    <img id="bg" src="bg.jpg" alt="Imagem de fundo" />
+    <img id="logo" src="logo.png" alt="Logo" />
+    <div class="overlay"></div>
+    <div class="content">
+      <span class="tag" id="tag">Categoria</span>
+      <h1 id="title">Faixa superior destaca o título principal com contraste</h1>
+      <p class="subtitle" id="subtitle">Espaço extra para descrição rápida ou chamada complementar na parte inferior.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/TemplateStoryTopoFaixaAmarelo/pagina1/styles.css
+++ b/templates/TemplateStoryTopoFaixaAmarelo/pagina1/styles.css
@@ -1,0 +1,110 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: #221200;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#art {
+  position: relative;
+  width: 1080px;
+  height: 1920px;
+  background: #221200;
+  color: #fdf4d4;
+  overflow: hidden;
+}
+
+#bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.4;
+  z-index: 1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(34, 18, 0, 0.2) 0%, rgba(34, 18, 0, 1) 100%);
+  z-index: 2;
+}
+
+#art::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 360px;
+  background: linear-gradient(90deg, #ffcd38 0%, #f7aa00 100%);
+  z-index: 3;
+}
+
+#logo {
+  position: absolute;
+  top: 110px;
+  right: 120px;
+  width: 180px;
+  height: 180px;
+  object-fit: contain;
+  z-index: 5;
+}
+
+.content {
+  position: relative;
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 420px 120px 140px;
+}
+
+.tag {
+  position: absolute;
+  top: 260px;
+  left: 120px;
+  padding: 12px 36px;
+  border-radius: 999px;
+  background: rgba(34, 18, 0, 0.9);
+  color: #ffcd38;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 1.8rem;
+}
+
+#title {
+  font-size: 4.4rem;
+  line-height: 1.1;
+  font-weight: 800;
+  color: #fff3c6;
+  max-width: 780px;
+}
+
+.subtitle {
+  font-size: 2.1rem;
+  line-height: 1.5;
+  color: #ffe394;
+  max-width: 760px;
+}
+
+.content::after {
+  content: '';
+  position: absolute;
+  bottom: 90px;
+  left: 120px;
+  width: 180px;
+  height: 180px;
+  border-radius: 32px;
+  border: 12px solid rgba(255, 205, 56, 0.35);
+}


### PR DESCRIPTION
## Summary
- replace the fixed template grid with a category-based story selector
- render story cards from a structured template catalog and update the modal logic
- add the 12 story template directories with their markup/styles plus preview documentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5d50cd548331a18481ec23de5ca7