### PR TITLE
Map story templates to shared story dimensions

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -2,17 +2,41 @@ const fs = require('fs');
 const path = require('path');
 const puppeteer = require('puppeteer');
 
+const STORY_TEMPLATE_DIMENSIONS = { width: 1080, height: 1920 };
+
+const storyTemplateIds = new Set([
+  'TemplateAGazetaStories',
+  'TemplateStoryFotoAcimaTituloAzul',
+  'TemplateStoryHzAgAmarelo'
+]);
+
+const templatesDir = path.join(__dirname, 'templates');
+if (fs.existsSync(templatesDir)) {
+  for (const entry of fs.readdirSync(templatesDir, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name.startsWith('TemplateStory')) {
+      storyTemplateIds.add(entry.name);
+    }
+  }
+}
+
 // Configuração de dimensões por template
 const templateDimensions = {
   'TemplateAGazeta': { width: 1080, height: 1350 },
-  'TemplateAGazetaStories': { width: 1080, height: 1920 },
   'TemplateAGazetaFeed': { width: 1080, height: 1080 },
   'TemplateSimples': { width: 1080, height: 1350 },
   'TemplateTopicos': { width: 1080, height: 1350 },
+  // Todas as variações de stories compartilham esta dimensão padrão (1080x1920).
+  ...Object.fromEntries([...storyTemplateIds].map(id => [id, STORY_TEMPLATE_DIMENSIONS])),
   'default': { width: 1080, height: 1350 }
 };
 
 function getTemplateDimensions(templateName) {
+  if (
+    storyTemplateIds.has(templateName) ||
+    (typeof templateName === 'string' && templateName.startsWith('TemplateStory'))
+  ) {
+    return STORY_TEMPLATE_DIMENSIONS;
+  }
   return templateDimensions[templateName] || templateDimensions['default'];
 }
 


### PR DESCRIPTION
## Summary
- ensure story templates such as TemplateStoryFotoAcimaTituloAzul and TemplateStoryHzAgAmarelo share the 1080x1920 viewport
- add inline documentation in generate.js explaining that story variations reuse the same dimensions and auto-detect TemplateStory folders

## Testing
- node generate.js *(fails: Puppeteer is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6877d2e88331a9ae94102ed5ac13